### PR TITLE
Added git params to .net assembly (RK-6265)

### DIFF
--- a/dotnet-aspnet/README.md
+++ b/dotnet-aspnet/README.md
@@ -36,6 +36,7 @@ Before following this guide we recommend reading the basic [DotNet + Rookout] gu
     ```xml
      <ItemGroup>
         <PackageReference Include="Rookout" Version="0.1.*" />
+        <PackageReference Include="MSBuildGitHash" Version="2.0.1" />
      </ItemGroup>
     ```
 2. Make sure you set the following properties in your .csproj file, under your PropertyGroup:
@@ -43,6 +44,7 @@ Before following this guide we recommend reading the basic [DotNet + Rookout] gu
     <PropertyGroup>        
         <EmbedAllSources>true</EmbedAllSources>
         <Optimize>false</Optimize>
+        <MSBuildGitHashCommand>git config --get remote.origin.url %26%26 git rev-parse HEAD</MSBuildGitHashCommand>
     </PropertyGroup>
     ```
 3. Start the Rookout SDK with the API:

--- a/dotnet-aspnet/dotnet-core-2/SimpleHttpServer.csproj
+++ b/dotnet-aspnet/dotnet-core-2/SimpleHttpServer.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <EmbedAllSources>true</EmbedAllSources>
     <Optimize>false</Optimize>
+    <MSBuildGitHashCommand>git config --get remote.origin.url %26%26 git rev-parse HEAD</MSBuildGitHashCommand>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Rookout" Version="0.1.*" />
+    <PackageReference Include="MSBuildGitHash" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-aspnet/dotnet-core-3/Program.cs
+++ b/dotnet-aspnet/dotnet-core-3/Program.cs
@@ -16,33 +16,8 @@ namespace SimpleHttpServer
 {
     public class Program
     {
-        private static string GetBuildHashFromAssembly()
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-            var customAttributes = assembly?.CustomAttributes ?? Enumerable.Empty<CustomAttributeData>();
-            return customAttributes
-                // MSBuildGitHash adds custom attribute to assembly of the following format:
-                // [assembly: AssemblyMetadata("GitHash", "MYHASHVAL")]
-                .Where(c => c.ConstructorArguments.Count >= 2 && c.ConstructorArguments[0].Value as string == "GitHash")
-                .Select(c => c.ConstructorArguments[1].Value as string)
-                .FirstOrDefault() ?? "??";
-        }
-        private static string GetBuildOriginFromAssembly()
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-            var customAttributes = assembly?.CustomAttributes ?? Enumerable.Empty<CustomAttributeData>();
-            return customAttributes
-                // MSBuildGitHash adds custom attribute to assembly of the following format:
-                // [assembly: AssemblyMetadata("GitRepository", "MYURL")]
-                .Where(c => c.ConstructorArguments.Count >= 2 && c.ConstructorArguments[0].Value as string == "GitRepository")
-                .Select(c => c.ConstructorArguments[1].Value as string)
-                .FirstOrDefault() ?? "??";
-        }
         public static void Main(string[] args)
         {
-            Console.WriteLine(GetBuildHashFromAssembly());
-            Console.WriteLine(GetBuildOriginFromAssembly());
-
 			Rook.RookOptions options = new Rook.RookOptions()
             {
                 labels = new Dictionary<string, string> { { "env", "dev" } }

--- a/dotnet-aspnet/dotnet-core-3/Program.cs
+++ b/dotnet-aspnet/dotnet-core-3/Program.cs
@@ -9,13 +9,40 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using Rook;
+using System.Reflection;
+
 
 namespace SimpleHttpServer
 {
     public class Program
     {
+        private static string GetBuildHashFromAssembly()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var customAttributes = assembly?.CustomAttributes ?? Enumerable.Empty<CustomAttributeData>();
+            return customAttributes
+                // MSBuildGitHash adds custom attribute to assembly of the following format:
+                // [assembly: AssemblyMetadata("GitHash", "MYHASHVAL")]
+                .Where(c => c.ConstructorArguments.Count >= 2 && c.ConstructorArguments[0].Value as string == "GitHash")
+                .Select(c => c.ConstructorArguments[1].Value as string)
+                .FirstOrDefault() ?? "??";
+        }
+        private static string GetBuildOriginFromAssembly()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var customAttributes = assembly?.CustomAttributes ?? Enumerable.Empty<CustomAttributeData>();
+            return customAttributes
+                // MSBuildGitHash adds custom attribute to assembly of the following format:
+                // [assembly: AssemblyMetadata("GitRepository", "MYURL")]
+                .Where(c => c.ConstructorArguments.Count >= 2 && c.ConstructorArguments[0].Value as string == "GitRepository")
+                .Select(c => c.ConstructorArguments[1].Value as string)
+                .FirstOrDefault() ?? "??";
+        }
         public static void Main(string[] args)
         {
+            Console.WriteLine(GetBuildHashFromAssembly());
+            Console.WriteLine(GetBuildOriginFromAssembly());
+
 			Rook.RookOptions options = new Rook.RookOptions()
             {
                 labels = new Dictionary<string, string> { { "env", "dev" } }

--- a/dotnet-aspnet/dotnet-core-3/Program.cs
+++ b/dotnet-aspnet/dotnet-core-3/Program.cs
@@ -9,8 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using Rook;
-using System.Reflection;
-
 
 namespace SimpleHttpServer
 {

--- a/dotnet-aspnet/dotnet-core-3/SimpleHttpServer.csproj
+++ b/dotnet-aspnet/dotnet-core-3/SimpleHttpServer.csproj
@@ -4,9 +4,13 @@
     <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <EmbedAllSources>true</EmbedAllSources>
     <Optimize>false</Optimize>
+    <MSBuildGitHashCommand>git rev-parse HEAD</MSBuildGitHashCommand>
+    <RepositoryUrl>https://github.com/Rookout/deployment-examples</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MSBuildGitHash" Version="2.0.1" />
     <PackageReference Include="Rookout" Version="0.1.*" />
   </ItemGroup>
 

--- a/dotnet-aspnet/dotnet-core-3/SimpleHttpServer.csproj
+++ b/dotnet-aspnet/dotnet-core-3/SimpleHttpServer.csproj
@@ -4,14 +4,12 @@
     <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <EmbedAllSources>true</EmbedAllSources>
     <Optimize>false</Optimize>
-    <MSBuildGitHashCommand>git rev-parse HEAD</MSBuildGitHashCommand>
-    <RepositoryUrl>https://github.com/Rookout/deployment-examples</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
+    <MSBuildGitHashCommand>git config --get remote.origin.url %26%26 git rev-parse HEAD</MSBuildGitHashCommand>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSBuildGitHash" Version="2.0.1" />
     <PackageReference Include="Rookout" Version="0.1.*" />
+    <PackageReference Include="MSBuildGitHash" Version="2.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. Use https://github.com/MarkPflug/MSBuildGitHash
2. Install it by adding to csproj: 
`<PackageReference Include="MSBuildGitHash" Version="2.0.1" />`
3. Make sure we get all the params:
Add this to get the full commit hash:
`<MSBuildGitHashCommand>git rev-parse HEAD</MSBuildGitHashCommand>`
Add these to get the URL: (this one is hard coded and not retrieved dynamically)
```
    <RepositoryUrl>https://github.com/Rookout/deployment-examples</RepositoryUrl>
    <RepositoryType>git</RepositoryType>
```

See example in program.cs on how to retrieve the data, anyway it should probably not be there as this is just for dev purposes.