### PR TITLE
RK-8484 - Lambda Node 8 runtime is deprecated

### DIFF
--- a/node-aws-lambda/Dockerfile
+++ b/node-aws-lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-nodejs8.10
+FROM lambci/lambda:build-nodejs10.x
 RUN mkdir -p /build
 RUN mkdir -p /dist
 WORKDIR /build


### PR DESCRIPTION
https://rookout.atlassian.net/browse/RK-8484