### PR TITLE
RK-8325 - Bugfix/python flask render template not found

### DIFF
--- a/node-aws-lambda/Dockerfile
+++ b/node-aws-lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-nodejs8.10
+FROM lambci/lambda:build-nodejs10.x
 RUN mkdir -p /build
 RUN mkdir -p /dist
 WORKDIR /build

--- a/python-flask/flask_rookout.py
+++ b/python-flask/flask_rookout.py
@@ -1,5 +1,5 @@
 import time
-from flask import Flask
+from flask import Flask, render_template
 from random import randint
 from datetime import datetime
 import rook


### PR DESCRIPTION
Did not import render_template function in flask_python.py

https://rookout.atlassian.net/browse/RK-8325