### PR TITLE
RK-10633 - RK-10633 - update gradle rook version to latest

### DIFF
--- a/java-gradle/java-agent/build.gradle
+++ b/java-gradle/java-agent/build.gradle
@@ -16,7 +16,7 @@ repositories {
 dependencies {
     compile group: 'io.javalin', name: 'javalin', version:'1.3.0'
     compile 'org.slf4j:slf4j-nop:1.7.25'
-    rookoutAgent 'com.rookout:rook:0.1.99'
+    rookoutAgent 'com.rookout:rook:+'
 }
 
 jar {

--- a/java-gradle/java-api/build.gradle
+++ b/java-gradle/java-api/build.gradle
@@ -12,7 +12,7 @@ repositories {
 dependencies {
     compile group: 'io.javalin', name: 'javalin', version:'1.3.0'
     compile 'org.slf4j:slf4j-nop:1.7.25'
-    compile group: 'com.rookout', name: 'rook', version: '0.1.99'
+    compile group: 'com.rookout', name: 'rook', version: '0.+'
 }
 
 jar {

--- a/java-gradle/java-dynamic-loading/build.gradle
+++ b/java-gradle/java-dynamic-loading/build.gradle
@@ -16,7 +16,7 @@ repositories {
 dependencies {
     compile group: 'io.javalin', name: 'javalin', version:'1.3.0'
     compile 'org.slf4j:slf4j-nop:1.7.25'
-    rookoutAgent 'com.rookout:rook:0.1.99'
+    rookoutAgent 'com.rookout:rook:+'
 }
 
 jar {


### PR DESCRIPTION
We should use the latest version and not pin to an old one