### PR TITLE
RK-14317 - limit import lib due to missing get

### DIFF
--- a/python-nameko/requirements.txt
+++ b/python-nameko/requirements.txt
@@ -1,2 +1,3 @@
 rook>=0.1.58
 nameko
+importlib-metadata<5.0


### PR DESCRIPTION
fix:
```
Traceback (most recent call last):
  File "/usr/local/bin/nameko", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/nameko/cli/main.py", line 143, in main
    args.main(args, *unknown_args)
  File "/usr/local/lib/python3.7/site-packages/nameko/cli/commands.py", line 112, in main
    from .run import main
  File "/usr/local/lib/python3.7/site-packages/nameko/cli/run.py", line 20, in <module>
    from nameko.runners import ServiceRunner
  File "/usr/local/lib/python3.7/site-packages/nameko/runners.py", line 6, in <module>
    from nameko.containers import get_container_cls, get_service_name
  File "/usr/local/lib/python3.7/site-packages/nameko/containers.py", line 15, in <module>
    from nameko import serialization
  File "/usr/local/lib/python3.7/site-packages/nameko/serialization.py", line 3, in <module>
    import kombu.serialization
  File "/usr/local/lib/python3.7/site-packages/kombu/serialization.py", line 440, in <module>
    for ep, args in entrypoints('kombu.serializers'):  # pragma: no cover
  File "/usr/local/lib/python3.7/site-packages/kombu/utils/compat.py", line 82, in entrypoints
    for ep in importlib_metadata.entry_points().get(namespace, [])
AttributeError: 'EntryPoints' object has no attribute 'get'
```